### PR TITLE
Add configurable colour to calendar

### DIFF
--- a/backend/foodbank_southlondon/api/views.py
+++ b/backend/foodbank_southlondon/api/views.py
@@ -8,10 +8,14 @@ from foodbank_southlondon.api import rest
 # CONFIG VARIABLES
 _FBSL_COLLECTION_CENTRES = "FBSL_COLLECTION_CENTRES"
 
+calendar = rest.model("Calendar", {
+    "id": fields.String(required=True, description="The calendar ID for a given collection centre",
+                        example="ca2ikhedkfjhawd213123@group.calendar.google.com"),
+    "colour": fields.String(required=True, description="Hex code colour for the calendar events")
+})
 
 _calendar_model = rest.model("Calendars", {
-    "calendar_ids": fields.List(fields.String(required=True, description="The escaped calendar ID for a given collection centre.",
-                                              example="ca2ikhedkfjhawd213123@group.calendar.google.com"))
+    "calendars": fields.List(fields.Nested(calendar))
 })
 
 
@@ -20,6 +24,10 @@ class Calendars(flask_restx.Resource):
 
     @rest.marshal_with(_calendar_model)
     def get(self):
+        centres = flask.current_app.config[_FBSL_COLLECTION_CENTRES].values()
+
         return {
-            "calendar_ids": [calendar["calendar_id"] for calendar in flask.current_app.config[_FBSL_COLLECTION_CENTRES].values()],
+            "calendars": [
+                {"id": centre["calendar_id"], "colour": centre["calendar_colour"]} for centre in centres
+            ]
         }

--- a/backend/foodbank_southlondon/api/views.py
+++ b/backend/foodbank_southlondon/api/views.py
@@ -25,9 +25,6 @@ class Calendars(flask_restx.Resource):
     @rest.marshal_with(_calendar_model)
     def get(self):
         centres = flask.current_app.config[_FBSL_COLLECTION_CENTRES].values()
-
         return {
-            "calendars": [
-                {"id": centre["calendar_id"], "colour": centre["calendar_colour"]} for centre in centres
-            ]
+            "calendars": [{"id": centre["calendar_id"], "colour": centre["calendar_colour"]} for centre in centres]
         }

--- a/frontend/src/components/calendar/index.jsx
+++ b/frontend/src/components/calendar/index.jsx
@@ -7,15 +7,19 @@ import Loading from '../common/loading';
 
 import './styles/index.scss';
 
-function CalendarEmbed({ ids }) {
+function CalendarEmbed({ calendars }) {
     const url = new URL("https://calendar.google.com/calendar/embed");
     
     url.searchParams.append('mode', 'WEEK');
     url.searchParams.append('hl', 'en_GB');
     url.searchParams.append('showTitle', '0');
 
-    for(const id of ids) {
-        url.searchParams.append('src', id);
+    for(const calendar of calendars) {
+        url.searchParams.append('src', calendar.id);
+    }
+
+    for(const calendar of calendars) {
+        url.searchParams.append('color', calendar.colour);
     }
 
     return <iframe
@@ -30,7 +34,7 @@ function CalendarEmbed({ ids }) {
 
 export default function Calendar() {
     const dispatch = useDispatch();
-    const { status, ids } = useSelector(({ calendars }) => calendars);
+    const { status, calendars } = useSelector(({ calendars }) => calendars);
 
     useEffect(() => {
         dispatch(fetchCalendars());
@@ -40,8 +44,8 @@ export default function Calendar() {
         return <span>Error loading calendars</span>;
     }
 
-    if(ids.length > 0) {
-        return <CalendarEmbed ids={ids} />;
+    if(calendars.length > 0) {
+        return <CalendarEmbed calendars={calendars} />;
     }
 
     return <Loading />;

--- a/frontend/src/redux/actions/index.js
+++ b/frontend/src/redux/actions/index.js
@@ -409,11 +409,11 @@ export const eventSubmitFailed = () => ({
 export const fetchCalendars = () => {
     return dispatch => {
         dispatch({ type: LOAD_CALENDARS })
-        getCalendars().then(({ calendar_ids }) => {
+        getCalendars().then(({ calendars }) => {
             dispatch({
                 type: CALENDARS_LOADED,
                 payload: {
-                    calendar_ids
+                    calendars
                 }
             });
         }).catch(() => {

--- a/frontend/src/redux/reducers/calendars.js
+++ b/frontend/src/redux/reducers/calendars.js
@@ -8,7 +8,7 @@ import { CALENDARS_LOADED, LOAD_CALENDARS, LOAD_CALENDARS_FAILED } from "../acti
 
 const initialState = {
     status: STATUS_IDLE,
-    ids: []
+    calendars: []
 };
 
 export default function(state = initialState, action) {
@@ -20,7 +20,7 @@ export default function(state = initialState, action) {
             return {
                 ...state,
                 status: STATUS_SUCCESS,
-                ids: action.payload.calendar_ids
+                calendars: action.payload.calendars
             };
 
         case LOAD_CALENDARS_FAILED:


### PR DESCRIPTION
Google Calendar embeds won't display events from different calendars in different colours unless instructed to in the embed URL itself. This PR adds the colour as a config option:

```
FBSL_COLLECTION_CENTRES={
  "Test 1": {
    "calendar_id": "b3U0cGUyMjJpM2JobzI0ZG80MjYwYzc5cGNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
    "calendar_colour": "#795548"},
  "Test 2": {
    "calendar_id": "Z24wZmJlY2NzYjFvN3VtcnJtNWpoNXE1ZGdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ",
    "calendar_colour": "#F6BF26"}
}
```

**Before**

<img width="1217" alt="Screenshot 2021-09-04 at 16 23 14" src="https://user-images.githubusercontent.com/395805/132099606-a6bb1c17-f92d-4d17-b9d2-4585882c972b.png">


**After**

<img width="1214" alt="Screenshot 2021-09-04 at 16 21 40" src="https://user-images.githubusercontent.com/395805/132099577-a17a8852-7dc3-4c48-9287-c0cfa99ebe6b.png">


It is possible to look up the colour for a given calendar using the API:

[GET CalendarLists?id=<_>](https://developers.google.com/calendar/api/v3/reference/calendarList/get)

```json
{
 "kind": "calendar#calendarListEntry",
 "etag": "\"1630766020702000\"",
 "id": "ou4pe222i3bho24do4260c79pc@group.calendar.google.com",
 "summary": "Foodbank Test 1",
 "timeZone": "Europe/London",
 "colorId": "1",
 "backgroundColor": "#ac725e",
 "foregroundColor": "#000000",
 "selected": true,
 "accessRole": "owner",
 "defaultReminders": [],
 "conferenceProperties": {
  "allowedConferenceSolutionTypes": [
   "hangoutsMeet"
  ]
 }
}
```

but I'm not sure it's worth it over config for what we're doing here. We could switch to that after this PR without changing the frontend anyway.
