### PR TITLE
Default calendar to a single day view of today

### DIFF
--- a/frontend/src/components/calendar/index.jsx
+++ b/frontend/src/components/calendar/index.jsx
@@ -7,10 +7,28 @@ import Loading from '../common/loading';
 
 import './styles/index.scss';
 
+function today() {
+    const now = new Date();
+    const year = now.getFullYear();
+    
+    // months are zero-based
+    let month = '' + (now.getMonth() + 1);
+    if(month.length === 1) {
+        month = '0' + month;
+    }
+
+    // horrible horrible JS API for getting the day of the month
+    let day = '' + now.getDate();
+    if(day.length === 1) {
+        day = '0' + day;
+    }
+
+    return year + month + day;
+}
+
 function CalendarEmbed({ calendars }) {
     const url = new URL("https://calendar.google.com/calendar/embed");
     
-    url.searchParams.append('mode', 'WEEK');
     url.searchParams.append('hl', 'en_GB');
     url.searchParams.append('showTitle', '0');
 
@@ -21,6 +39,13 @@ function CalendarEmbed({ calendars }) {
     for(const calendar of calendars) {
         url.searchParams.append('color', calendar.colour);
     }
+
+    // weeks start on Monday
+    url.searchParams.append('wkst', '2');
+
+    // default to showing a single day view of today
+    url.searchParams.append('mode', 'day');
+    url.searchParams.append('dates', `${today()}/${today()}`);
 
     return <iframe
         title='Foodbank Calendar'


### PR DESCRIPTION
Google Calendar embeds don't give you the option of a single day view unless you default to it using an undocumented parameter: https://webapps.stackexchange.com/questions/3431/is-it-possible-to-link-to-specific-date-on-a-public-google-calendar