### PR TITLE
Extend the hover area on delivery/collection to be the full cell width

### DIFF
--- a/frontend/src/components/requests/list.jsx
+++ b/frontend/src/components/requests/list.jsx
@@ -6,7 +6,7 @@ import Flag from './flag';
 import './styles/list.scss';
 import { FilterFieldValues } from '../lists/value-filters';
 import Loading from '../common/loading';
-import { RequestIcons } from './request-icons';
+import { RequestIconCell } from './request-icons';
 
 export default class RequestsList extends React.Component {
 
@@ -86,9 +86,7 @@ export default class RequestsList extends React.Component {
                     <td>
                         { request.postcode }
                     </td>
-                    <td>
-                        <RequestIcons request={request} />
-                    </td>
+                    <RequestIconCell request={request} />
                     <td>{ format(request.packingDate, DATE_FORMAT_UI) }</td>
                     <td>{ request.timeOfDay }</td>
                     <td>{ this.extractEvent(request.event) }</td>

--- a/frontend/src/components/requests/request-icons.jsx
+++ b/frontend/src/components/requests/request-icons.jsx
@@ -3,45 +3,49 @@ import React from "react";
 import congestionChargeLogo from '../../assets/congestion-charge.png';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-export function RequestIcons({ request }) {
+export function RequestIconCell({ request }) {
     const icons = [];
 
+    let title = '';
+
     if(request.collectionCentre) {
-        const alt = `Collection at ${request.collectionCentre}`;
+        title = `Collection at ${request.collectionCentre}`;
+
         const icon = <FontAwesomeIcon
             key='collection'
             className='inline-icon'
             icon='shoe-prints'
-            title={alt}
-            alt={alt}
+            alt={title}
         />;
         
         icons.push(icon);
     } else {
+        title = 'Delivery';
+
         const icon = <FontAwesomeIcon
             key='delivery'
             className='inline-icon'
             icon='truck'
-            title='Delivery'
-            alt='Delivery'
+            alt={title}
         />;
 
         icons.push(icon);
     }
 
     if(request.isInCongestionZone && !request.collectionCentre) {
+        title = 'Congestion charge applies';
+
         const icon = <img
             key='congestion_charge'
             className='inline-icon'
             src={congestionChargeLogo}
-            alt='Congestion charge'
-            title='Congestion charge applies'
+            alt={title}
         />;
 
         icons.push(icon);
     }
 
-    return <React.Fragment>
+    return <td title={title}>
         { icons }
-    </React.Fragment>;
+    </td>;
 }


### PR DESCRIPTION
At the moment it's hard to hit the hover because you have to be exactly over the icon which is about half as tall as the table cell and certainly a lot less wide. This PR changes the `title` attribute to apply to the entire table cell.

**Before**

<img width="1227" alt="Screenshot 2021-09-13 at 18 16 30" src="https://user-images.githubusercontent.com/395805/133127994-763edda9-d8a6-4300-bdcc-e98c8ac2dcac.png">

**After**

<img width="1228" alt="Screenshot 2021-09-13 at 18 14 41" src="https://user-images.githubusercontent.com/395805/133127839-052f6c43-17a8-4a08-8d8f-050f495e505d.png">

In either case Safari takes over a second to display the native tooltip, much slower than Firefox or Chrome. We will consider a different way of presenting this info that doesn't rely on them.