### PR TITLE
Add phone_numbers param to filtering requests and expose to bff too

### DIFF
--- a/backend/foodbank_southlondon/api/requests/parsers.py
+++ b/backend/foodbank_southlondon/api/requests/parsers.py
@@ -17,8 +17,9 @@ requests_params.add_argument("postcodes", type=str, required=False, action="spli
 requests_params.add_argument("time_of_days", type=str, required=False, action="split", help="A comma separated list of Times of Day to filter on.")
 requests_params.add_argument("voucher_numbers", type=str, required=False, action="split", help="A comma separated list of Voucher Numbers to "
                              "filter on")
-requests_params.add_argument("collection_centres", type=str, required=False, action="split", help="A comma sepaerated list of Collection Centres to "
+requests_params.add_argument("collection_centres", type=str, required=False, action="split", help="A comma separated list of Collection Centres to "
                              "filter on.")
+requests_params.add_argument("phone_numbers", type=str, required=False, action="split", help="A comma separated list of Phone Numbers to filter on.")
 requests_params.add_argument(_events_params_args["event_names"])
 requests_params.add_argument("last_request_only", type=inputs.boolean, required=False, help="Whether only the most recent request per Client Full "
                              "Name will be fetched")

--- a/backend/foodbank_southlondon/api/requests/views.py
+++ b/backend/foodbank_southlondon/api/requests/views.py
@@ -46,6 +46,7 @@ class Requests(flask_restx.Resource):
         time_of_days = set(time_of_day.strip() for time_of_day in (params["time_of_days"] or ()))
         voucher_numbers = set("" if voucher_number.strip() == "?" else voucher_number.strip() for voucher_number in (params["voucher_numbers"] or ()))
         collection_centres = set(collection_centre.strip() for collection_centre in (params["collection_centres"] or ()))
+        phone_numbers = set(phone_number.strip() for phone_number in (params["phone_numbers"] or ()))
         event_names = set(event_name.strip() for event_name in (params["event_names"] or ()))
         invalid_event_names = event_names.difference(events_models.EVENT_NAMES)
         if invalid_event_names:
@@ -69,6 +70,8 @@ class Requests(flask_restx.Resource):
             df = df.loc[df["Time of Day"].isin(time_of_days)]
         if collection_centres:
             df = df.loc[df["Collection Centre"].isin(collection_centres)]
+        if phone_numbers:
+            df = df.loc[df["Phone Number"].isin(phone_numbers)]
         if event_names:
             events_df = events_views.cache(force_refresh=refresh_cache)
             events_df = (

--- a/backend/foodbank_southlondon/bff/parsers.py
+++ b/backend/foodbank_southlondon/bff/parsers.py
@@ -21,6 +21,7 @@ summary_params.add_argument(_requests_params_args["postcodes"])
 summary_params.add_argument(_requests_params_args["time_of_days"])
 summary_params.add_argument(_requests_params_args["voucher_numbers"])
 summary_params.add_argument(_requests_params_args["collection_centres"])
+summary_params.add_argument(_requests_params_args["phone_numbers"])
 summary_params.add_argument(_requests_params_args["event_names"])
 
 action_params = reqparse.RequestParser(trim=True)

--- a/backend/foodbank_southlondon/bff/views.py
+++ b/backend/foodbank_southlondon/bff/views.py
@@ -306,6 +306,7 @@ class Summary(flask_restx.Resource):
         # Preserve the empty string to filter by delivery only
         _collection_centres = params["collection_centres"]
         collection_centres = ",".join(_collection_centres) if _collection_centres is not None else None
+        phone_numbers = ",".join(params["phone_numbers"] or ()) or None
         event_names = ",".join(params["event_names"] or ()) or None
         per_page = params["per_page"]
         api_base_url = _api_base_url()
@@ -316,7 +317,8 @@ class Summary(flask_restx.Resource):
                                       "total_items, total_pages"},
                              params={"client_full_names": client_full_names, "packing_dates": packing_dates, "postcodes": postcodes,
                                      "time_of_days": time_of_days, "voucher_numbers": voucher_numbers, "collection_centres": collection_centres,
-                                     "event_names": event_names, "refresh_cache": refresh_cache, "page": params["page"], "per_page": per_page})
+                                     "phone_numbers": phone_numbers, "event_names": event_names, "refresh_cache": refresh_cache,
+                                     "page": params["page"], "per_page": per_page})
         requests_df = pd.DataFrame(requests_data["items"])
         if not requests_df.empty:
             events_df = None


### PR DESCRIPTION
Exposes a new param to both bff/summary and api/requests. Like the existing params, acceptable value is actually comma-delimited string even though users tend to not be aware of this and just filter on one at a time. Also, I didn't bother with any value normalisation in the end because it isn't a consistent approach with what I do elsewhere - so it's basically just a dumb exact match but given the form validation, we can be confident values will be a continuous string of digits anyway. If the user misses 0 off in the form, well, they better miss 0 off in their search too!

Needs extra field in frontend. I think we said initially we'd just squeeze one in and look at a prettier UX later on.