### PR TITLE
Pin Werkzeug to fix JSON parsing error in the bff during local dev

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,5 +11,5 @@ python-dotenv
 pytz
 requests
 weasyprint
-werkzeug
+werkzeug==2.0.3
 wrapt


### PR DESCRIPTION
Fixes a weird problem where requests to the bff fail with:

```
Did not attempt to load JSON data because the request Content-Type was not 'application/json'
```

The api endpoints were unaffected.

I don't know why it happens but the nice people on this thread suggested pinning Werkzeug to 2.0.3 and that fixed it for me https://github.com/schuderer/mllaunchpad/issues/152