### PR TITLE
Add signposting call/phone icon

### DIFF
--- a/frontend/src/components/requests/list.jsx
+++ b/frontend/src/components/requests/list.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { format } from 'date-fns';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import { COLLECTION_CENTRES_FILTER_KEY, DATE_FORMAT_UI, STATUSES_FILTER_KEY, TIME_OF_DAY_FILTER_KEY } from '../../constants';
-import Flag from './flag';
 import './styles/list.scss';
 import { FilterFieldValues } from '../lists/value-filters';
 import Loading from '../common/loading';
@@ -77,7 +76,12 @@ export default class RequestsList extends React.Component {
                             checked={ item.checked } />
                     </td>
                     <td className="cell-trim">
-                        { request.flagForAttention && <Flag /> }
+                        { request.flagForAttention &&
+                            <Icon icon="flag" className="flag inline-icon" title="Flagged for attention" />
+                        }
+                        { request.signpostingCall &&
+                            <Icon icon="phone" className="phone inline-icon" title="Requires follow up phone call" />
+                        }
                     </td>
                     <td>
                         { request.fullName }

--- a/frontend/src/components/requests/styles/flag.scss
+++ b/frontend/src/components/requests/styles/flag.scss
@@ -1,5 +1,0 @@
-@import 'include';
-
-.flag {
-    color: $colour-danger;
-}

--- a/frontend/src/components/requests/styles/list.scss
+++ b/frontend/src/components/requests/styles/list.scss
@@ -12,3 +12,7 @@
 .requests-list .inline-icon-text {
     margin-left: $pad-standard;
 }
+
+.flag {
+    color: $colour-danger;
+}

--- a/frontend/src/icons/index.js
+++ b/frontend/src/icons/index.js
@@ -21,7 +21,8 @@ import {
     faSync,
     faFilter,
     faShoePrints,
-    faTruck
+    faTruck,
+    faPhone
 } from '@fortawesome/free-solid-svg-icons'
 import {
     faSave
@@ -53,7 +54,8 @@ export default function setupIcons() {
         faSync,
         faFilter,
         faShoePrints,
-        faTruck
+        faTruck,
+        faPhone
     );
 
     // Regular icons

--- a/frontend/src/service/index.js
+++ b/frontend/src/service/index.js
@@ -181,6 +181,7 @@ export function getRequests(filters = {}, page = 1, refreshCache=false) {
                 postcode: item.postcode,
                 isInCongestionZone: item.congestion_zone,
                 flagForAttention: item.flag_for_attention,
+                signpostingCall: item.signposting_call,
                 collectionCentre: item.collection_centre,
                 collectionCentreAbbr: item.collection_centre_abbr
             }));


### PR DESCRIPTION
Adds a phone icon if a signposting call has been requested.

The tooltip text says "Requires follow up phone call" but happy to change that to whatever is best.

<img width="1790" alt="Screenshot 2022-06-01 at 11 51 00" src="https://user-images.githubusercontent.com/395805/171366349-e4e35c49-6ad5-40ef-9799-5f6fab245c7b.png">
