### PR TITLE
[list redesign] 02: New list with sticky headers

### DIFF
--- a/frontend/src/components/requests/filter.jsx
+++ b/frontend/src/components/requests/filter.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import DateRangePicker from '../common/date-range-picker';
 import FilterField from './filter-field';
+import { COLLECTION_CENTRES_FILTER_KEY, STATUSES_FILTER_KEY, TIME_OF_DAY_FILTER_KEY } from '../../constants';
+import { FilterFieldValues } from '../lists/value-filters';
 import './styles/filter.scss';
 
 
@@ -58,7 +60,11 @@ export default class RequestsFilter extends React.Component {
         return this.state.showAdditional
             ? (
                 <div className="additional-filter">
-                    <h4>Additional filters</h4>
+                    <h4>Filter</h4>
+                    Collection Centres: <FilterFieldValues attribute={COLLECTION_CENTRES_FILTER_KEY} />
+                    Time Of Day: <FilterFieldValues attribute={TIME_OF_DAY_FILTER_KEY} />
+                    Statuses: <FilterFieldValues attribute={STATUSES_FILTER_KEY} />
+                    <h4>Search</h4>
                     <FilterField label="Search names..."
                         value={ this.state.name }
                         onChange={ this.onNameChange }

--- a/frontend/src/components/requests/index.jsx
+++ b/frontend/src/components/requests/index.jsx
@@ -24,6 +24,7 @@ import Paginator from '../common/paginator';
 import Error from '../common/error';
 import RequestsFilter from './filter';
 import RequestsList from './list';
+import NewRequestsList from './new-list';
 import RequestsActions from './actions';
 import RequestSelection from './selection';
 import RequestsEventDialog from './event-dialog';
@@ -134,7 +135,13 @@ class Requests extends React.Component {
             <div className="requests-contents">
                 {loading && !empty ? <div className="requests-blinder"></div> : false}
                 {this.props.newListDesignEnabled ?
-                    <>TODO: not implemented yet</>
+                    <NewRequestsList
+                        requests={ this.props.items }
+                        loading={ loading }
+                        onSelect={ id => this.selectRequest(id) }
+                        onToggle={ id => this.toggleRequest(id) }
+                        onToggleAll={ () => this.toggleAllRequests() }
+                        onRefresh={() => this.fetchRequests(this.props.filters, this.props.paging.page, true) } />
                 :
                     <RequestsList
                         requests={ this.props.items }

--- a/frontend/src/components/requests/list.jsx
+++ b/frontend/src/components/requests/list.jsx
@@ -8,6 +8,14 @@ import { FilterFieldValues } from '../lists/value-filters';
 import Loading from '../common/loading';
 import { RequestIconCell } from './request-icons';
 
+export function extractEvent(event) {
+    if (!event.name) return '';
+    const date = format(event.date, DATE_FORMAT_UI);
+    return !!event.data
+        ? `${ event.name } (${ event.data }) @ ${ date }`
+        : `${ event.name } @ ${ date }`;
+}
+
 export default class RequestsList extends React.Component {
 
     toggle(id) {
@@ -24,14 +32,6 @@ export default class RequestsList extends React.Component {
 
     handleCheckboxClick(event) {
         event.stopPropagation();
-    }
-
-    extractEvent(event) {
-        if (!event.name) return '';
-        const date = format(event.date, DATE_FORMAT_UI);
-        return !!event.data
-            ? `${ event.name } (${ event.data }) @ ${ date }`
-            : `${ event.name } @ ${ date }`;
     }
 
     getEmptyRow() {
@@ -89,7 +89,7 @@ export default class RequestsList extends React.Component {
                     <RequestIconCell request={request} />
                     <td>{ format(request.packingDate, DATE_FORMAT_UI) }</td>
                     <td>{ request.timeOfDay }</td>
-                    <td>{ this.extractEvent(request.event) }</td>
+                    <td>{ extractEvent(request.event) }</td>
                 </tr>
             );
         });

--- a/frontend/src/components/requests/new-list.jsx
+++ b/frontend/src/components/requests/new-list.jsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import { DATE_FORMAT_UI } from '../../constants';
+import Loading from '../common/loading';
+import Flag from './flag';
+import { extractEvent } from './list';
+
+function groupTitle(request) {
+    const parts = [
+        format(request.packingDate, DATE_FORMAT_UI),
+        request.timeOfDay,
+        request.collectionCentre ? request.collectionCentre : 'Delivery'
+    ];
+
+    return parts.join(" - ");
+}
+
+// (collection/delivery, packing date, time)
+function groupRequests(requests) {
+    const ret = [];
+
+    let group = [requests[0]];
+
+    for(let i = 1; i < requests.length; i++) {
+        const request = requests[i];
+        const lastRequest = requests[i - 1];
+
+        if(request.data.collectionCentre !== lastRequest.data.collectionCentre ||
+            request.data.packingDate.getTime() !== lastRequest.data.packingDate.getTime() ||
+            request.data.timeOfDay !== lastRequest.data.timeOfDay) {
+                ret.push(group);
+                group = [];
+        }
+
+        group.push(request);
+    }
+
+    ret.push(group);
+
+    return ret;
+}
+
+function EmptyListBody({ loading }) {
+    return <tbody>
+        <tr className="empty-row">
+            <td colSpan="6">
+                {loading ? <Loading /> : "No results"}
+            </td>
+        </tr>
+    </tbody>;
+}
+
+function Request({ request, onToggle, onSelect }) {
+    const { checked, data: { id, flagForAttention, fullName, householdSize, postcode, event }} = request;
+    const disabled = !id.length;
+
+    return <tr onClick={onSelect}>
+        <td className="selection-cell">
+            <input type="checkbox"
+                disabled={disabled}
+                onChange={onToggle}
+                onClick={(e) => e.stopPropagation()}
+                checked={checked} />
+        </td>
+        <td className="cell-trim">
+            { flagForAttention && <Flag /> }
+        </td>
+        <td>
+            { fullName }
+        </td>
+        <td>{ householdSize }</td>
+        <td>
+            { postcode }
+        </td>
+        <td>{ extractEvent(event) }</td>
+    </tr>;
+}
+
+function NewListBody({ requests, onToggle, onSelect }) {
+    const groupedRequests = groupRequests(requests);
+
+    return <tbody>
+        {
+            groupedRequests.flatMap(group => {
+                const title = groupTitle(group[0].data);
+            
+                return [
+                    <tr key={title} className='inline-header-row'>
+                        <th className='inline-header' colSpan='6'>{title}</th>
+                    </tr>,
+                    ...group.map((request) =>
+                        <Request
+                            key={request.data.id}
+                            request={request}
+                            onToggle={() => onToggle(request.data.id)}
+                            onSelect={() => onSelect(request.data.id)}
+                        />
+                    )
+                ]
+            })
+        }
+    </tbody>;
+}
+
+export default function NewList({ requests, loading, onSelect, onToggle, onToggleAll, onRefresh }) {
+    const hasData = requests.length > 0;
+    const allChecked = requests.every(request => request.checked);
+
+    function refresh() {
+        if(!loading) {
+            onRefresh();
+        }
+    }
+
+    return <table className="requests-list selectable">
+        <thead>
+            <tr>
+                <th className="selection-cell">
+                    <input type="checkbox"
+                        onChange={onToggleAll}
+                        disabled={!hasData}
+                        checked={hasData && allChecked} />
+                </th>
+                <th className="cell-trim"></th>
+                <th>Name</th>
+                <th>Family Size</th>
+                <th>Postcode</th>
+                <th>
+                    <div className="cell-with-actions">
+                        Last Status
+                        <button onClick={refresh}>
+                            <Icon
+                                icon="sync"
+                                title="Refresh"
+                                spin={loading}
+                            />
+                        </button>
+                    </div>
+                </th>
+            </tr>
+        </thead>
+        { hasData ?
+            <NewListBody
+                requests={requests}
+                onToggle={onToggle}
+                onSelect={onSelect}
+            /> :
+            <EmptyListBody loading={loading} />
+        }
+    </table>;
+}

--- a/frontend/src/components/requests/styles/index.scss
+++ b/frontend/src/components/requests/styles/index.scss
@@ -9,6 +9,7 @@
         background-color: $colour-white;
         // Ensure the React datepicker appears above other content
         z-index: 1;
+        height: $toolbar-height;
     }
 
     .requests-controls {

--- a/frontend/src/components/requests/styles/list.scss
+++ b/frontend/src/components/requests/styles/list.scss
@@ -12,3 +12,8 @@
 .requests-list .inline-icon-text {
     margin-left: $pad-standard;
 }
+
+.requests-list .inline-header {
+    position: sticky;
+    top: $toolbar-height;
+}

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -125,7 +125,7 @@ tbody tr:nth-child(even) {
 
 table {
 
-    &.selectable tbody tr:not(.empty-row):not(.disabled) {
+    &.selectable tbody tr:not(.empty-row):not(.disabled):not(.inline-header-row) {
         cursor: pointer;
 
         &:hover {
@@ -140,6 +140,7 @@ table {
     .cell-with-actions {
         display: flex;
         align-items: center;
+        justify-content: space-between;
     }
 
     .cell-actions {
@@ -157,6 +158,12 @@ table {
 
     .row-with-divider-below {
         border-bottom: $pad-half solid $colour-main-bold;
+    }
+
+    .inline-header {
+        background-color: $colour-main-bold;
+        text-transform: uppercase;
+        color: $colour-white;
     }
 }
 

--- a/frontend/src/styles/_include.scss
+++ b/frontend/src/styles/_include.scss
@@ -68,6 +68,9 @@ $breakpoint-medium: 960px;
 $breakpoint-large: 1200px;
 $breakpoint-x-large: 1200px;
 
+// Fixed height elements
+
+$toolbar-height: 4rem;
 
 // Mixins
 


### PR DESCRIPTION
NB: this is behind a feature flag and requires #107 

Condense information repeated on each row into headers that stick in place as you scroll:

https://user-images.githubusercontent.com/395805/171400823-d3a46198-2445-4146-bedb-9e34c3874545.mov

Unfortunately this design doesn't have the headers where we used to have the filter buttons. A future PR will add the filters in a different place.
