### PR TITLE
Unfloat additional filters

### DIFF
--- a/frontend/src/components/requests/styles/index.scss
+++ b/frontend/src/components/requests/styles/index.scss
@@ -9,7 +9,6 @@
         background-color: $colour-white;
         // Ensure the React datepicker appears above other content
         z-index: 1;
-        height: $toolbar-height;
     }
 
     .requests-controls {


### PR DESCRIPTION
In #108 I made it so the additional filters drop down floats over the headers. User feedback is that they prefer it to push down the table instead of floating.

Ignore the horrible dithering pattern below - I converted the videos to gif using a free online converter and it did a rubbish job of it.

**Before this PR**

![183261739-ffb3c073-9c1d-4c65-a94e-7dbcdcd442d4](https://user-images.githubusercontent.com/395805/184149331-6767ab67-13e2-4538-be54-a1c72a84ccb5.gif)

**After this PR**

![183261730-33a98944-6e01-4f40-89cf-1a31fdb423bb](https://user-images.githubusercontent.com/395805/184149392-784fad17-6cba-4be8-82fe-7cda2d1d09ba.gif)

